### PR TITLE
functionality to define included host files outside of of the lwrp

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,6 +11,7 @@ default['dhcp']['allows'] = ['booting', 'bootp', 'unknown-clients']
 
 # these are the arrays that dispatch to bags or attributes for actual data
 default['dhcp']['hosts'] = []
+default['dhcp']['hosts_files'] = []
 default['dhcp']['groups'] = []
 default['dhcp']['networks'] = []
 default['dhcp']['interfaces'] = []

--- a/recipes/_hosts.rb
+++ b/recipes/_hosts.rb
@@ -43,4 +43,17 @@ unless node['dhcp']['hosts'].empty?
       conf_dir node['dhcp']['dir']
     end
   end
+
+else
+
+  template "#{node['dhcp']['dir']}/hosts.d/list.conf" do
+    source 'list.conf.erb'
+    owner 'root'
+    group 'root'
+    mode 0644
+    variables(files: node['dhcp']['hosts_files'])
+    notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
+    not_if { node['dhcp']['hosts_files'].nil? }
+  end
+
 end


### PR DESCRIPTION
Have a use case where dhcpd configuration is generated outside of chef.

Id simply like to tell the cookbook to include this file.

