### PR TITLE
Fixing README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Data bag and Attribute driven DHCP server.
 * Supports setting up Master/Master isc DHCP failover.
 * Includes Support for ddns
 * Includes LWRPs for managing hosts, groups and subnets.
-* Use databags or attributes + wrapper cooks to manage dhcp server [Example](examples/attribute_driven.rb)
+* Use databags or attributes + wrapper cooks to manage dhcp server [Example](examples/attribute_based.rb)
 
 Large parts were borrowed from  work initially done by Dell, extended by Atalanta Systems and reworked by Matt Ray and Opscode. Big thanks to all of them.
 


### PR DESCRIPTION
The link to the file was outdated, pointing to a file that doesn't exist.