### PR TITLE
added "allow" functionality to subnet pool definition

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ issues_url "https://github.com/chef-brigade/#{name}-cookbook/issues" if respond_
 license 'Apache 2.0'
 description 'DHCP'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '5.1.0'
+version '5.1.1'
 
 # tested with Ubuntu, assume Debian works similarly
 %w(debian ubuntu centos redhat).each do |os|

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ issues_url "https://github.com/chef-brigade/#{name}-cookbook/issues" if respond_
 license 'Apache 2.0'
 description 'DHCP'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '5.1.2'
+version '5.1.0'
 
 # tested with Ubuntu, assume Debian works similarly
 %w(debian ubuntu centos redhat).each do |os|

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ issues_url "https://github.com/chef-brigade/#{name}-cookbook/issues" if respond_
 license 'Apache 2.0'
 description 'DHCP'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '5.1.1'
+version '5.1.2'
 
 # tested with Ubuntu, assume Debian works similarly
 %w(debian ubuntu centos redhat).each do |os|

--- a/recipes/_networks.rb
+++ b/recipes/_networks.rb
@@ -23,7 +23,7 @@ node['dhcp']['networks'].each do |net|
       pool do
         range data['range'] if data.key? 'range'
         peer node['domain'] if node['dhcp']['failover']
-        allow data['allow'] if data['allow']
+        allow data['allow'] if data.key? allow
       end
     end
     ddns data['ddns'] if data.key? 'ddns'
@@ -50,7 +50,7 @@ if node['dhcp']['use_bags']
             pool do
               range data['range'] if data.key? 'range'
               peer node['domain'] if node['dhcp']['failover']
-              allow data['allow'] if data['allow']
+              allow data['allow'] if data.key? allow
             end
           end
           ddns data['ddns'] if data.key? 'ddns'
@@ -79,7 +79,7 @@ unless node['dhcp']['use_bags']
             pool do
               range data['range'] if data.key? 'range'
               peer node['domain'] if node['dhcp']['failover']
-              allow data['allow'] if data['allow']
+              allow data['allow'] if data.key? allow
             end
           end
           ddns data['ddns'] if data.key? 'ddns'

--- a/recipes/_networks.rb
+++ b/recipes/_networks.rb
@@ -23,6 +23,7 @@ node['dhcp']['networks'].each do |net|
       pool do
         range data['range'] if data.key? 'range'
         peer node['domain'] if node['dhcp']['failover']
+        allow data['allow'] if data['allow']
       end
     end
     ddns data['ddns'] if data.key? 'ddns'
@@ -49,6 +50,7 @@ if node['dhcp']['use_bags']
             pool do
               range data['range'] if data.key? 'range'
               peer node['domain'] if node['dhcp']['failover']
+              allow data['allow'] if data['allow']
             end
           end
           ddns data['ddns'] if data.key? 'ddns'
@@ -77,6 +79,7 @@ unless node['dhcp']['use_bags']
             pool do
               range data['range'] if data.key? 'range'
               peer node['domain'] if node['dhcp']['failover']
+              allow data['allow'] if data['allow']
             end
           end
           ddns data['ddns'] if data.key? 'ddns'

--- a/recipes/_networks.rb
+++ b/recipes/_networks.rb
@@ -23,7 +23,7 @@ node['dhcp']['networks'].each do |net|
       pool do
         range data['range'] if data.key? 'range'
         peer node['domain'] if node['dhcp']['failover']
-        allow data['allow'] if data.key? allow
+        allow data['allow'] if data.key? 'allow'
       end
     end
     ddns data['ddns'] if data.key? 'ddns'
@@ -50,7 +50,7 @@ if node['dhcp']['use_bags']
             pool do
               range data['range'] if data.key? 'range'
               peer node['domain'] if node['dhcp']['failover']
-              allow data['allow'] if data.key? allow
+              allow data['allow'] if data.key? 'allow'
             end
           end
           ddns data['ddns'] if data.key? 'ddns'
@@ -79,7 +79,7 @@ unless node['dhcp']['use_bags']
             pool do
               range data['range'] if data.key? 'range'
               peer node['domain'] if node['dhcp']['failover']
-              allow data['allow'] if data.key? allow
+              allow data['allow'] if data.key? 'allow'
             end
           end
           ddns data['ddns'] if data.key? 'ddns'

--- a/resources/pool.rb
+++ b/resources/pool.rb
@@ -3,3 +3,4 @@ default_action :nothing
 attribute :range, kind_of: [Array, String]
 attribute :peer, kind_of: String, default: nil
 attribute :deny, kind_of: String, default: nil
+attribute :allow, kind_of: String, default: nil

--- a/templates/default/subnet.erb
+++ b/templates/default/subnet.erb
@@ -1,7 +1,7 @@
 subnet <%= @subnet %> netmask <%= @netmask%> {
 <% unless @pools.nil? || @pools.empty? -%>
 <% @pools.each do |pool| -%>
-<%= render 'subnet_pool.erb', :cookbook => 'dhcp', :variables => { node: @node, peer: pool.peer, range: pool.range, deny: pool.deny } %>
+<%= render 'subnet_pool.erb', :cookbook => 'dhcp', :variables => { node: @node, peer: pool.peer, range: pool.range, deny: pool.deny, allow: pool.allow } %>
 <% end -%>
 <% end -%>
 <% if @ddns -%>

--- a/templates/default/subnet_pool.erb
+++ b/templates/default/subnet_pool.erb
@@ -10,6 +10,6 @@ pool {
   deny <%= @deny %>;
   <% end -%>
   <% if @allow -%>
-  deny <%= @allow %>;
+  allow <%= @allow %>;
   <% end -%>
 }

--- a/templates/default/subnet_pool.erb
+++ b/templates/default/subnet_pool.erb
@@ -9,4 +9,7 @@ pool {
   <% if @deny -%>
   deny <%= @deny %>;
   <% end -%>
+  <% if @allow -%>
+  deny <%= @allow %>;
+  <% end -%>
 }

--- a/test/cookbooks/testing/recipes/dhcp_class.rb
+++ b/test/cookbooks/testing/recipes/dhcp_class.rb
@@ -26,6 +26,6 @@ dhcp_subnet 'allow host from class' do
   routers ['192.168.4.1']
   pool do
     range '192.168.4.20 192.168.4.30'
-    deny 'allow of "RegisteredHosts"'
+    allow 'members of "RegisteredHosts"'
   end
 end

--- a/test/cookbooks/testing/recipes/dhcp_class.rb
+++ b/test/cookbooks/testing/recipes/dhcp_class.rb
@@ -18,3 +18,14 @@ dhcp_subnet 'deny host from class' do
     deny 'members of "RegisteredHosts"'
   end
 end
+
+dhcp_subnet 'allow host from class' do
+  subnet '192.168.4.0'
+  broadcast '192.168.4.255'
+  netmask '255.255.255.0'
+  routers ['192.168.4.1']
+  pool do
+    range '192.168.4.20 192.168.4.30'
+    deny 'allow of "RegisteredHosts"'
+  end
+end

--- a/test/cookbooks/testing/recipes/dhcp_subnet.rb
+++ b/test/cookbooks/testing/recipes/dhcp_subnet.rb
@@ -26,6 +26,7 @@ dhcp_subnet 'overrides' do
     peer '192.168.0.2'
     range '192.168.0.100 192.168.0.200'
     deny 'members of "RegisteredHosts"'
+    allow 'members of "RegisteredHosts"'
   end
   ddns 'test.com'
   evals [%q(


### PR DESCRIPTION
I wanted the ability to be able to limit certain subnets to a defined class (i.e. match only mac addresses of virtualbox VMs)