### PR TITLE
Tag 5.3.0 is broken, fully remove Helpers::DataBag use

### DIFF
--- a/recipes/_hosts.rb
+++ b/recipes/_hosts.rb
@@ -28,7 +28,7 @@ unless node['dhcp']['hosts'].empty?
 
   host_list.each do  |host|
     if node['dhcp']['use_bags'] == true
-      host_data = data_bag_item(node['dhcp']['hosts_bag'], Helpers::DataBags.escape_bagname(host))
+      host_data = data_bag_item(node['dhcp']['hosts_bag'], Dhcp::Helpers.escape_bagname(host))
     else
       host_data = node['dhcp']['host_data'].fetch host, nil
     end


### PR DESCRIPTION
After commit 35d01b8e4e66e7aa94e102ce873bbf067cd61b89, fully remove Helpers::DataBag