### PR TITLE
fix for issue #69 - adding support for dhcp hooks

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -76,3 +76,5 @@ when 'debian'
   default['dhcp']['dhcpd_leases'] = '/var/lib/dhcp/dhcpd.leases'
   default['dhcp']['init_iface'] = 'INTERFACES'
 end
+
+default['dhcp']['hooks'] = []

--- a/recipes/_config.rb
+++ b/recipes/_config.rb
@@ -17,6 +17,7 @@ template node['dhcp']['config_file'] do
     allows: node['dhcp']['allows'] || [],
     parameters: node['dhcp']['parameters'] || [],
     options: node['dhcp']['options'] || [],
+    hooks: node[:dhcp][:hooks],
     masters: DHCP::DynaDns.masters,
     keys: DHCP::DynaDns.keys,
     my_ip: node['dhcp']['my_ip'] || node['ipaddress'],

--- a/recipes/_config.rb
+++ b/recipes/_config.rb
@@ -17,7 +17,7 @@ template node['dhcp']['config_file'] do
     allows: node['dhcp']['allows'] || [],
     parameters: node['dhcp']['parameters'] || [],
     options: node['dhcp']['options'] || [],
-    hooks: node[:dhcp][:hooks],
+    hooks: node['dhcp']['hooks'],
     masters: DHCP::DynaDns.masters,
     keys: DHCP::DynaDns.keys,
     my_ip: node['dhcp']['my_ip'] || node['ipaddress'],

--- a/templates/default/dhcpd.conf.erb
+++ b/templates/default/dhcpd.conf.erb
@@ -15,6 +15,16 @@ allow <%= allow %>;
 option <%= key %> <%= value %>;
 <% end -%>
 
+<% unless @hooks.nil? || @hooks.empty?  -%>
+  <% @hooks.each_pair do |key, value| -%>
+  on <%= key %> {
+     <% value.each do |v| -%>
+      <%= v %>;
+     <% end -%>
+  <% end -%>
+    }
+<% end -%>
+
 <% unless @keys.nil? || @keys.empty? -%>
   <% @keys.each do |key, data| -%>
 key "<%= key %>" {


### PR DESCRIPTION
adding the default['dhcp']['hooks'] attribute to add hooks to the dhcpd.conf file